### PR TITLE
BUG: ringElem doesn't change size on rotate (iPad)

### DIFF
--- a/standalone/flying-focus.js
+++ b/standalone/flying-focus.js
@@ -27,7 +27,7 @@ docElem.addEventListener('keydown', function(event) {
 }, false);
 
 
-docElem.addEventListener('focus', function(event) {
+docElem.addEventListener('focus resize', function(event) {
 	var target = event.target;
 	if (target.id === 'flying-focus') {
 		return;


### PR DESCRIPTION
We've encountered an issue in a project that appears under certain circumstances on ipads. Replication steps:
1. load a page at landscape on an ipad
2. focus to a form field, 
3. switch to portrait 

Result: it doesn't redraw the width and height of the flying focus element. This means that when a field is close to the right hand side of a page, it will create empty space out the side until the field is unfocussed.

NOTE: This could also be an issue with the other version of the script, but I haven't tested it with that version.
